### PR TITLE
Implement custom title logic to avoid inclusion of tagline

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,14 @@
 
 <head>
   <meta charset="UTF-8">
-  {% seo %}
+  <title>
+    {% if page.title == site.title %}
+      {{ page.title }}
+    {% else %}
+      {{ page.title }} | {{ site.title }}
+    {% endif %}
+  </title>
+  {% seo title=false %}
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link rel="preload" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700&display=swap" as="style"
     type="text/css" crossorigin>


### PR DESCRIPTION
Before:
<img width="1725" alt="Screenshot 2023-04-17 at 14 13 39" src="https://user-images.githubusercontent.com/3018395/232494611-d4c36b8e-87ee-45c2-ae9b-00873874d3a8.png">

After:
<img width="1722" alt="Screenshot 2023-04-17 at 14 12 39" src="https://user-images.githubusercontent.com/3018395/232494321-5809a370-cc39-4745-ae5b-36eb5ea364ce.png">
