### PR TITLE
Apply button hover styles to focus state

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -28,7 +28,7 @@ $hr-border-color: #7A444A;
     color: #FFF;
     border-color: $border-color;
 
-    &:hover {
+    &:hover, &:focus-visible {
     color: $section-headings-color;
     text-decoration: none;
     background-color: #FFF;


### PR DESCRIPTION
The browser-native focus outline (blue outline in Chrome) is preserved, to help users distinguish between the hover state and the focus state.

See also: https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible for an explanation of `:focus-visible` Vs. `:focus`

Before:
<img width="1728" alt="Screenshot 2023-04-18 at 10 46 53" src="https://user-images.githubusercontent.com/3018395/232739953-ebf34c53-a2a2-4753-b4b3-0eb1827820a6.png">

After:
<img width="1727" alt="Screenshot 2023-04-18 at 10 47 03" src="https://user-images.githubusercontent.com/3018395/232739998-a3a68e06-d748-42ad-891e-cb1043e7749f.png">

For comparison, here's what the button hover style looks like:
<img width="1721" alt="Screenshot 2023-04-18 at 10 47 10" src="https://user-images.githubusercontent.com/3018395/232740110-f9a2ad90-bef1-40b9-974e-d3426188e407.png">
